### PR TITLE
Fix Colors 0.13 incompatibility because of old registry entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,11 @@
 name = "Animations"
 uuid = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 
 [compat]
 julia = "1"
-Colors = "0"
+Colors = "0 - 0.13"


### PR DESCRIPTION
Animations got capped to 0.12 in this PR four years ago https://github.com/JuliaRegistries/General/pull/21961/files

Tagging this patch version will update the boundaries.